### PR TITLE
Pull request 1119 UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "^2.53.2"
+        "@tacc/core-styles": "^2.53.3"
       },
       "engines": {
         "node": ">=16",
@@ -1403,16 +1403,16 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.53.2",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.53.2.tgz",
-      "integrity": "sha512-S6LX0Ggn7Ua97omauSSrmKjuLagB27M7uIPYCzo7PHk0kecr2KrJYtgUGCKWDmCnAgoSK7zD76ok4CwqA3eRjQ==",
+      "version": "2.53.3",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.53.3.tgz",
+      "integrity": "sha512-Rr9JBB88ES/kbwcN3C2zqELb/thAEMWj6T1y40X4jK1HsGi84RfwPzUflo16STzIxN8NWV2b0eeTwyOnm6M/4A==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "core-styles": "src/cli.js"
       },
       "engines": {
-        "node": ">=15.x",
+        "node": ">=20.x",
         "npm": ">=7.x"
       },
       "peerDependencies": {
@@ -5593,9 +5593,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.53.2",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.53.2.tgz",
-      "integrity": "sha512-S6LX0Ggn7Ua97omauSSrmKjuLagB27M7uIPYCzo7PHk0kecr2KrJYtgUGCKWDmCnAgoSK7zD76ok4CwqA3eRjQ==",
+      "version": "2.53.3",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.53.3.tgz",
+      "integrity": "sha512-Rr9JBB88ES/kbwcN3C2zqELb/thAEMWj6T1y40X4jK1HsGi84RfwPzUflo16STzIxN8NWV2b0eeTwyOnm6M/4A==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "^2.53.2"
+    "@tacc/core-styles": "^2.53.3"
   }
 }

--- a/taccsite_cms/templates/cms_menu.html
+++ b/taccsite_cms/templates/cms_menu.html
@@ -8,37 +8,53 @@
 {% limit_visibility_in_menu child as can_view %}
 {% if can_view %}
 
-<li class="nav-item{% if child.selected or child.ancestor %} active{% endif %}{% if child.children %} dropdown{% endif %}">
+<li class="
+  nav-item
+  {% if child.selected or child.ancestor %}
+  active
+  {% endif %}
   {% if child.children %}
-    <a
-      href=""
+  dropdown
+  {% endif %}"
+>
+  {% if child.children %}
+    <button
       class="nav-link dropdown-toggle"
       data-toggle="dropdown"
       aria-haspopup="true"
       aria-expanded="false"
       aria-controls="nav-menu-{{child.id}}"
-      role="button"
       id="nav-link-{{child.id}}"
       >
       {{ child.get_menu_title|safe }}
       {% if child.selected %}<span class="sr-only">(current)</span>{% endif %}
       <span class="sr-only">Toggle Dropdown</span>
-    </a>
-    <div class="dropdown-menu" role="menu" id="nav-menu-{{child.id}}" aria-labelledby="nav-link-{{child.id}}">
+    </button>
+    <nav class="dropdown-menu" id="nav-menu-{{child.id}}" aria-labelledby="nav-link-{{child.id}}">
       {# Bootstrap4 does not support submenus, so nor do we (and other users). See https://github.com/twbs/bootstrap/pull/6342. #}
       {% for grandchild in child.children %}
       {% limit_visibility_in_menu grandchild as can_view %}
       {% if can_view %}
 
-      <a class="dropdown-item{% if grandchild.selected %} active{% endif %}" href="{{ grandchild|get_menu_uri }}" role="menuitem" {% target_blank grandchild|get_menu_uri %}>
+      <a
+        class="dropdown-item{% if grandchild.selected %} active{% endif %}"
+        href="{{ grandchild|get_menu_uri }}"
+        role="menuitem"
+        {% target_blank grandchild|get_menu_uri %}
+      >
         {{ grandchild.get_menu_title|safe }}
         {% if grandchild.selected %}<span class="sr-only">(current)</span>{% endif %}
       </a>
 
       {% endif %}
       {% endfor %}
+    </nav>
   {% else %}
-  <a class="nav-link" href="{{ child|get_menu_uri }}" {% target_blank child|get_menu_uri %}>
+  <a
+    class="nav-link"
+    href="{{ child|get_menu_uri }}"
+    {% target_blank child|get_menu_uri %}
+  >
     {{ child.get_menu_title|safe }}
     {% if child.selected %}<span class="sr-only">(current)</span>{% endif %}
   </a>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

Applies and tests the changes from `Core-CMS/pull/1119` to improve the semantic HTML of the site's navigation dropdowns and updates `@tacc/core-styles`.

## Related

- [TACC/Core-CMS/pull/1119](https://github.com/TACC/Core-CMS/pull/1119)

## Changes

-   `taccsite_cms/templates/cms_menu.html`: Refactored navigation dropdowns to use semantic HTML: `<button>` for dropdown toggles (instead of `<a>` with `role="button"`) and `<nav>` for dropdown menus (instead of `<div>` with `role="menu"`), also adding a previously missing `</nav>` closing tag.
-   `package.json` / `package-lock.json`: Updated `@tacc/core-styles` from 2.53.2 to 2.53.3.

## Testing

1.  Verified CSS build (`npm ci && npm run build`).
2.  Collected static files (`manage.py collectstatic`).
3.  Confirmed site accessibility at `localhost:8000`.
4.  Manually tested header navigation: all items render, both dropdowns (Research, People) open correctly with no visual regression.
5.  Inspected with DevTools to confirm `<button>` and `<nav>` semantic tags are present in the rendered HTML.

## UI

Header navigation renders and behaves correctly, dropdowns open, links navigate, and UX is visually unchanged. DevTools confirms semantic markup changes: `<button class="nav-link dropdown-toggle">` and `<nav class="dropdown-menu">` with correct closing tags.

<div><a href="https://cursor.com/agents/bc-1b8a18e0-914b-4a09-91e4-f5f4568f7e25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b8a18e0-914b-4a09-91e4-f5f4568f7e25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->